### PR TITLE
restoring compatibility with PHP <7

### DIFF
--- a/stemmer.c
+++ b/stemmer.c
@@ -32,8 +32,7 @@ zend_module_entry stemmer_module_entry = {
 ZEND_GET_MODULE(stemmer)
 #endif
 
-
-
+#if PHP_MAJOR_VERSION < 7
 PHP_FUNCTION(stemword)
 {
     zval *lang, *enc, *arg;
@@ -54,12 +53,59 @@ PHP_FUNCTION(stemword)
     if(Z_TYPE_P(arg) == IS_ARRAY)
     {
       array_init(return_value);
-      zval *data;
       HashTable *arr_hash;
       HashPosition pointer;
       int array_count;
       arr_hash = Z_ARRVAL_P(arg);
       array_count = zend_hash_num_elements(arr_hash);
+      zval **data;
+      for( zend_hash_internal_pointer_reset_ex(arr_hash,&pointer);
+           zend_hash_get_current_data_ex(arr_hash,(void **)&data, &pointer)==SUCCESS;
+           zend_hash_move_forward_ex(arr_hash,&pointer) ){
+                  
+          const sb_symbol *stemmed = "";
+          if(Z_TYPE_PP(data) == IS_STRING){
+             stemmed = sb_stemmer_stem(stemmer, Z_STRVAL_PP(data), Z_STRLEN_PP(data));
+          }
+          add_next_index_string(return_value,stemmed, 1);         
+      }
+    }else{
+      convert_to_string(arg);    
+      const sb_symbol *stemmed = sb_stemmer_stem(stemmer, Z_STRVAL_P(arg), Z_STRLEN_P(arg));
+      if(stemmed)ZVAL_STRING( return_value, stemmed, 1); 
+    }
+    sb_stemmer_delete(stemmer);
+    
+   // RETURN_STRING(stemmed, 1);
+   //return 1;
+}
+#else
+PHP_FUNCTION(stemword)
+{
+    zval *lang, *enc, *arg;
+    
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "zzz", &arg,&lang,&enc) == FAILURE)RETURN_NULL();
+      
+    convert_to_string(lang);
+    convert_to_string(enc);
+                   
+    struct sb_stemmer * stemmer;
+    
+    //char * language = "kraaij_pohlmann";
+    //char * charenc = "UTF_8";
+        
+    stemmer = sb_stemmer_new(Z_STRVAL_P(lang),Z_STRVAL_P(enc));
+    if(!stemmer) RETURN_NULL();
+    
+    if(Z_TYPE_P(arg) == IS_ARRAY)
+    {
+      array_init(return_value);
+      HashTable *arr_hash;
+      HashPosition pointer;
+      int array_count;
+      arr_hash = Z_ARRVAL_P(arg);
+      array_count = zend_hash_num_elements(arr_hash);
+      zval *data;
       for( zend_hash_internal_pointer_reset_ex(arr_hash,&pointer);
            zend_hash_get_current_data_ex(arr_hash,(void *)&data)==SUCCESS;
            zend_hash_move_forward_ex(arr_hash,&pointer) ){
@@ -80,5 +126,5 @@ PHP_FUNCTION(stemword)
    // RETURN_STRING(stemmed, 1);
    //return 1;
 }
-
+#endif
 


### PR DESCRIPTION
- changes in last commit updated the code to compile for PHP 7 but was no longer backwards compatible with PHP 5.x
- this update simply restores the old code and decides additionally and decides which to use conditionally based on the PHP major version
- there may be a cleaner way to do this. I haven't done much C coding lately and even less so PHP extentions.
